### PR TITLE
Dashboard for tank analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # barc_blanket
+
+
+## Install environment
+
+```
+conda env create -f environment.yml
+```
+
+```
+conda activate barc-blanket-env
+```

--- a/barc_blanket/tank_analysis_dashboard.py
+++ b/barc_blanket/tank_analysis_dashboard.py
@@ -1,0 +1,52 @@
+from dash import Dash, dcc, html, Input, Output
+import plotly.express as px
+import pandas as pd
+
+
+def data_from_single_tank(tank_id):
+    # Filter the data for the tank_id
+    tank_data = df[df["WasteSiteId"] == tank_id]
+    return tank_data
+
+
+app = Dash(__name__)
+
+df = pd.read_csv("Tanks_Slurry_Inventory - all_tank_data.csv")
+
+app.layout = html.Div(
+    [
+        html.H4("Tank analysis"),
+        dcc.Graph(id="graph"),
+        html.P("Tank ID:"),
+        dcc.Dropdown(
+            id="tankID",
+            value="241-TX-101",
+            options=df["WasteSiteId"].unique(),
+        ),
+        html.P("Values:"),
+        dcc.Dropdown(
+            id="values",
+            options=["Mass (kg)", "Activity (Ci)", "WastePhase Mass (kg)"],
+            value="Mass (kg)",
+            clearable=False,
+        ),
+    ]
+)
+
+
+@app.callback(
+    Output("graph", "figure"), Input("tankID", "value"), Input("values", "value")
+)
+def generate_chart(tankID, field):
+    df_tank = data_from_single_tank(tankID)
+    df_tank = df_tank.groupby("Analyte").sum()
+    df_tank = df_tank.reset_index()
+    print(df_tank)
+    # only represent large values
+    df_tank.loc[df_tank[field] < 1 / 100 * df_tank[field].sum(), "Analyte"] = "Others"
+
+    fig = px.pie(df_tank, values=field, names="Analyte", hole=0.3)
+    return fig
+
+
+app.run_server(debug=True)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: barc-blanket-env
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - numpy
+  - pandas
+  - matplotlib
+  - openmc
+  - dash
+  - plotly
+  - pip


### PR DESCRIPTION
This PR adds a dashboard (with Dash) to analyse the tanks.

@j-fletcher it will need some additional work cause right now it's only plotting the raw data and has some stuff like both UTOTAL and 238U

I added a Conda environment to make it reproducible and added the installation instructions in the Readme.
You don't _have_ to use Conda but it's just a method to have a reproducible dev environment.

To run the dashboard, simply go the barc_blanket directory and run
```
python tank_analysis_dashboard.py
```

It will print something like:

```
Dash is running on http://127.0.0.1:8050/
```

And you can visualise this in any browser.

![image](https://github.com/j-fletcher/barc_blanket/assets/40028739/dc419600-f958-4c54-91df-13378cb57e5b)
